### PR TITLE
feat: 增加 CtxOfficeId 方法从context中解析officeId，更新依赖

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -2,10 +2,11 @@ package nie
 
 import (
 	"context"
-	"github.com/go-kratos/kratos/v2/errors"
-	"github.com/go-kratos/kratos/v2/metadata"
 	"strconv"
 	"strings"
+
+	"github.com/go-kratos/kratos/v2/errors"
+	"github.com/go-kratos/kratos/v2/metadata"
 )
 
 const (
@@ -14,6 +15,7 @@ const (
 	CtxEnterpriseIdKey = "enterpriseId"
 	CtxUnameKey        = "uname"
 	CtxRoleKey         = "role"
+	CtxOfficeIdKey     = "officeId"
 )
 
 // CtxGlobalInt 从上下文中获取元数据
@@ -75,4 +77,9 @@ func CtxUname(ctx context.Context) string {
 // CtxRoleKeys 从上下文中获取角色
 func CtxRoleKeys(ctx context.Context) []string {
 	return ctxArr(ctx, CtxRoleKey)
+}
+
+// CtxOfficeId 从上下文中获取单位ID
+func CtxOfficeId(ctx context.Context) int64 {
+	return ctxInt(ctx, CtxOfficeIdKey)
 }

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/go-kratos/kratos/v2 v2.8.4
 	github.com/jinzhu/copier v0.4.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/redis/go-redis/v9 v9.7.3
+	github.com/redis/go-redis/v9 v9.12.1
 	google.golang.org/protobuf v1.36.5
-	gorm.io/datatypes v1.2.5
-	gorm.io/gorm v1.25.12
+	gorm.io/datatypes v1.2.6
+	gorm.io/gorm v1.30.1
 )
 
 require (
@@ -26,5 +26,5 @@ require (
 	golang.org/x/text v0.21.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240102182953-50ed04b92917 // indirect
 	google.golang.org/grpc v1.61.1 // indirect
-	gorm.io/driver/mysql v1.5.7 // indirect
+	gorm.io/driver/mysql v1.6.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/redis/go-redis/v9 v9.7.3 h1:YpPyAayJV+XErNsatSElgRZZVCwXX9QzkKYNvO7x0wM=
 github.com/redis/go-redis/v9 v9.7.3/go.mod h1:bGUrSggJ9X9GUmZpZNEOQKaANxSGgOEBRltRTZHSvrA=
+github.com/redis/go-redis/v9 v9.12.1 h1:k5iquqv27aBtnTm2tIkROUDp8JBXhXZIVu1InSgvovg=
+github.com/redis/go-redis/v9 v9.12.1/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
 golang.org/x/crypto v0.22.0 h1:g1v0xeRhjcugydODzvb3mEM9SQ0HGp9s/nh3COQ/C30=
 golang.org/x/crypto v0.22.0/go.mod h1:vr6Su+7cTlO45qkww3VDJlzDn0ctJvRgYbC2NvXHt+M=
 golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
@@ -63,8 +65,12 @@ google.golang.org/protobuf v1.36.5 h1:tPhr+woSbjfYvY6/GPufUoYizxw1cF/yFoxJ2fmpwl
 google.golang.org/protobuf v1.36.5/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gorm.io/datatypes v1.2.5 h1:9UogU3jkydFVW1bIVVeoYsTpLRgwDVW3rHfJG6/Ek9I=
 gorm.io/datatypes v1.2.5/go.mod h1:I5FUdlKpLb5PMqeMQhm30CQ6jXP8Rj89xkTeCSAaAD4=
+gorm.io/datatypes v1.2.6 h1:KafLdXvFUhzNeL2ncm03Gl3eTLONQfNKZ+wJ+9Y4Nck=
+gorm.io/datatypes v1.2.6/go.mod h1:M2iO+6S3hhi4nAyYe444Pcb0dcIiOMJ7QHaUXxyiNZY=
 gorm.io/driver/mysql v1.5.7 h1:MndhOPYOfEp2rHKgkZIhJ16eVUIRf2HmzgoPmh7FCWo=
 gorm.io/driver/mysql v1.5.7/go.mod h1:sEtPWMiqiN1N1cMXoXmBbd8C6/l+TESwriotuRRpkDM=
+gorm.io/driver/mysql v1.6.0 h1:eNbLmNTpPpTOVZi8MMxCi2aaIm0ZpInbORNXDwyLGvg=
+gorm.io/driver/mysql v1.6.0/go.mod h1:D/oCC2GWK3M/dqoLxnOlaNKmXz8WNTfcS9y5ovaSqKo=
 gorm.io/driver/postgres v1.5.0 h1:u2FXTy14l45qc3UeCJ7QaAXZmZfDDv0YrthvmRq1l0U=
 gorm.io/driver/postgres v1.5.0/go.mod h1:FUZXzO+5Uqg5zzwzv4KK49R8lvGIyscBOqYrtI1Ce9A=
 gorm.io/driver/sqlite v1.4.3 h1:HBBcZSDnWi5BW3B3rwvVTc510KGkBkexlOg0QrmLUuU=
@@ -74,3 +80,5 @@ gorm.io/driver/sqlserver v1.5.4/go.mod h1:+frZ/qYmuna11zHPlh5oc2O6ZA/lS88Keb0XSH
 gorm.io/gorm v1.25.7/go.mod h1:hbnx/Oo0ChWMn1BIhpy1oYozzpM15i4YPuHDmfYtwg8=
 gorm.io/gorm v1.25.12 h1:I0u8i2hWQItBq1WfE0o2+WuL9+8L21K9e2HHSTE/0f8=
 gorm.io/gorm v1.25.12/go.mod h1:xh7N7RHfYlNc5EmcI/El95gXusucDrQnHXe0+CgWcLQ=
+gorm.io/gorm v1.30.1 h1:lSHg33jJTBxs2mgJRfRZeLDG+WZaHYCk3Wtfl6Ngzo4=
+gorm.io/gorm v1.30.1/go.mod h1:8Z33v652h4//uMA76KjeDH8mJXPm1QNCYrMeatR0DOE=


### PR DESCRIPTION
This pull request introduces a new context key and accessor for `officeId` in the `nie` package, and updates several dependencies to their latest versions. The main changes are grouped below:

Context key and accessor enhancements:

* Added a new constant `CtxOfficeIdKey` and a corresponding function `CtxOfficeId(ctx context.Context) int64` to retrieve the office ID from context metadata. (`ctx.go`) [[1]](diffhunk://#diff-c4dd82978a1a49bcd620aff72208bbd8114f09341d701e188c247ce3e3511117R18) [[2]](diffhunk://#diff-c4dd82978a1a49bcd620aff72208bbd8114f09341d701e188c247ce3e3511117R81-R85)

Dependency updates:

* Upgraded `github.com/redis/go-redis/v9` from `v9.7.3` to `v9.12.1`. (`go.mod`)
* Upgraded `gorm.io/datatypes` from `v1.2.5` to `v1.2.6` and `gorm.io/gorm` from `v1.25.12` to `v1.30.1`. (`go.mod`)
* Upgraded `gorm.io/driver/mysql` from `v1.5.7` to `v1.6.0`. (`go.mod`)

Other code maintenance:

* Cleaned up import ordering in `ctx.go` for better readability. (`ctx.go`)