### PR TITLE
feat: mark CaptchaPrefix and AccessTokenPrefix as deprecated; refactor AsyncDelRedis for asynchronous deletion

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -14,8 +14,11 @@ import (
 var DefaultCache *Cache
 
 var (
-	CaptchaPrefix      = "captcha:"      // 验证码前缀
-	AccessTokenPrefix  = "accessToken:"  // accessToken前缀
+	// Deprecated: it will be removed
+	CaptchaPrefix = "captcha:" // 验证码前缀
+	// Deprecated: it will be removed
+	AccessTokenPrefix = "accessToken:" // accessToken前缀
+	// Deprecated: it will be removed
 	RefreshTokenPrefix = "refreshToken:" // refreshToken前缀
 )
 
@@ -58,7 +61,6 @@ func (c *Cache) AsyncSetRedis(key string, data interface{}, expiration time.Dura
 		// 使用独立超时上下文，不影响主流程
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		// 直接调用上面定义的SetStruct
 		if err := c.SetRedis(ctx, key, data, expiration); err != nil && logHelper != nil {
 			logHelper.Errorf("async set redis failed for key %s: %v", key, err)
 		}
@@ -92,12 +94,15 @@ func (c *Cache) DelRedis(ctx context.Context, key string) error {
 }
 
 // AsyncDelRedis 异步删除缓存
-func (c *Cache) AsyncDelRedis(ctx context.Context, key string, logHelper *log.Helper) error {
-	err := c.DelRedis(ctx, key)
-	if err != nil && logHelper != nil {
-		logHelper.Errorf("async delete redis failed for key '%s': %v", key, err)
-	}
-	return err
+func (c *Cache) AsyncDelRedis(key string, logHelper *log.Helper) {
+	go func() {
+		// 使用独立超时上下文，不影响主流程
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := c.DelRedis(ctx, key); err != nil && logHelper != nil {
+			logHelper.Errorf("async delete redis failed for key '%s': %v", key, err)
+		}
+	}()
 }
 
 // 判断是否为基本数据类型（避免对基本类型进行JSON序列化）


### PR DESCRIPTION
This pull request to `cache.go` focuses on deprecating certain cache key prefixes and refactoring the asynchronous Redis deletion method for improved reliability and consistency. The most important changes are grouped below:

Deprecation of cache key prefixes:
* Marked `CaptchaPrefix`, `AccessTokenPrefix`, and `RefreshTokenPrefix` as deprecated, indicating these constants will be removed in the future.

Async Redis operation improvements:
* Refactored `AsyncDelRedis` to run deletion in a separate goroutine with its own timeout context, ensuring the main flow is not blocked and improving error handling. The function no longer returns an error.
* Updated `AsyncSetRedis` to clarify usage of a dedicated timeout context, ensuring asynchronous set operations do not affect the main process.