### PR TITLE
feat[copier]: 处理空对象和JSON null的兼容性

### DIFF
--- a/copier_ent_benchmark_test.go
+++ b/copier_ent_benchmark_test.go
@@ -153,6 +153,50 @@ func TestConverter_LabelsSliceToJSON_CompatWithEncodingJSON(t *testing.T) {
 	}
 }
 
+func TestConverter_JSONNullToLabelsSlice_ReturnsNil(t *testing.T) {
+	from := &entFromLabelsJSON{Labels: datatypes.JSON([]byte("null"))}
+	to := &entToLabelsSlice{}
+	if err := Copier4Ent(to, from); err != nil {
+		t.Fatalf("Copier4Ent error: %v", err)
+	}
+	if to.Labels != nil {
+		t.Fatalf("expected Labels to be nil, got len=%d", len(to.Labels))
+	}
+}
+
+func TestConverter_EmptyObjectToLabelsSlice_ReturnsNil(t *testing.T) {
+	from := &entFromLabelsJSON{Labels: datatypes.JSON([]byte("{}"))}
+	to := &entToLabelsSlice{}
+	if err := Copier4Ent(to, from); err != nil {
+		t.Fatalf("Copier4Ent error: %v", err)
+	}
+	if to.Labels != nil {
+		t.Fatalf("expected Labels to be nil, got len=%d", len(to.Labels))
+	}
+}
+
+func TestConverter_JSONNullToStructPBSlice_ReturnsNil(t *testing.T) {
+	from := &entToMetasJSON{Metas: datatypes.JSON([]byte("null"))}
+	to := &entFromMetasPB{}
+	if err := Copier4Ent(to, from); err != nil {
+		t.Fatalf("Copier4Ent error: %v", err)
+	}
+	if to.Metas != nil {
+		t.Fatalf("expected Metas to be nil, got len=%d", len(to.Metas))
+	}
+}
+
+func TestConverter_EmptyObjectToStructPBSlice_ReturnsNil(t *testing.T) {
+	from := &entToMetasJSON{Metas: datatypes.JSON([]byte("{}"))}
+	to := &entFromMetasPB{}
+	if err := Copier4Ent(to, from); err != nil {
+		t.Fatalf("Copier4Ent error: %v", err)
+	}
+	if to.Metas != nil {
+		t.Fatalf("expected Metas to be nil, got len=%d", len(to.Metas))
+	}
+}
+
 func BenchmarkCopier4Ent_LabelsSliceToJSON(b *testing.B) {
 	from := &entFromLabelsSlice{Labels: []string{"a", "b", "c", "d", "e"}}
 	b.ResetTimer()


### PR DESCRIPTION
1. 原因：在处理JSON数据时，空对象"{}"和JSON null需要特殊处理，以避免返回非预期的结果。
2. 实现：新增isEmptyJSONObjectBytes函数，判断字节数组是否为空对象，并在Copier4Ent中进行相应处理。
3. 影响：确保在处理脏数据时，返回nil切片，保持与json.Unmarshal一致的行为。