### PR TITLE
feat[缓存]: 新增Redis原子自增功能并刷新过期时间`IncrRedis()`

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -128,6 +128,20 @@ func (c *Cache) AsyncDelRedis(key string, logHelper *log.Helper) {
 	}()
 }
 
+// IncrRedis 对 key 执行原子自增并设置/刷新过期时间，返回自增后的值
+// 适用于频率限制、登录失败计数等场景
+func (c *Cache) IncrRedis(ctx context.Context, key string, expiration time.Duration) (int64, error) {
+	val, err := c.redis.Incr(ctx, key).Result()
+	if err != nil {
+		return 0, err
+	}
+	// 每次自增后刷新过期时间，确保窗口期从最近一次操作开始计算
+	if expiration > 0 {
+		_ = c.redis.Expire(ctx, key, expiration)
+	}
+	return val, nil
+}
+
 // TTLRefresh 刷新缓存过期时间
 func (c *Cache) TTLRefresh(ctx context.Context, key string, expiration time.Duration) error {
 	return c.redis.Expire(ctx, key, expiration).Err()


### PR DESCRIPTION
This pull request introduces a new atomic increment method to the `Cache` struct, specifically for Redis keys. This method is designed to support use cases like rate limiting and login failure counting by incrementing a key and refreshing its expiration window after each operation.

New Redis atomic increment functionality:

* Added `IncrRedis` method to `Cache`, which atomically increments a Redis key and refreshes its expiration time, returning the new value. This is useful for scenarios such as rate limiting and counting login failures.